### PR TITLE
Fix typos, add Main element in Tech Docs

### DIFF
--- a/src/project-tests/bar-chart-tests.js
+++ b/src/project-tests/bar-chart-tests.js
@@ -110,7 +110,7 @@ export default function createBarChartTests() {
 
             // promise is used to prevent test from ending prematurely
             return new Promise((resolve, reject) => {
-                // timeout is used to accomodate tooltip transitions
+                // timeout is used to accommodate tooltip transitions
                 setTimeout(_ => {
                     if (FCC_Global.getToolTipStatus(tooltip) !== 'visible') {
                         reject('Tooltip should be visible when mouse is on a bar ');

--- a/src/project-tests/calculator-tests.js
+++ b/src/project-tests/calculator-tests.js
@@ -89,7 +89,7 @@ export default function createCalculatorTests() {
 
             it("9. In any order, I should be able to add, subtract, multiply and divide a chain of numbers of any length, and when I hit =, the correct result should be shown in the element with the id of \"display\"", function() {
                 clickButtonsById([_3, _plus, _5, _x, _6, _min, _2, _div, _4, _eq]);
-                FCC_Global.assert(document.getElementById("display").innerHTML === "32.5" || document.getElementById("display").innerHTML === "11.5", "Equation should produce 32.5 or 11.5 as an answer, depening on the logic your calculator uses (formula vs. immediate execution)");
+                FCC_Global.assert(document.getElementById("display").innerHTML === "32.5" || document.getElementById("display").innerHTML === "11.5", "Equation should produce 32.5 or 11.5 as an answer, depending on the logic your calculator uses (formula vs. immediate execution)");
             });
 
             it("10. When inputting numbers, my calculator should not allow a number to begin with multiple zeros.", function() {

--- a/src/project-tests/choropleth-tests.js
+++ b/src/project-tests/choropleth-tests.js
@@ -66,7 +66,7 @@ export default function createChoroplethTests() {
                     uniqueFipsFromChoropleth.push(+fips);
                 }
 
-                // iterate through each data point and make sure all given data appears on the Choropleth, and that the Choropleth doesn't contain extra data                      
+                // iterate through each data point and make sure all given data appears on the Choropleth, and that the Choropleth doesn't contain extra data
                 for (var j = 0; j < educationData.length; j++) {
                     // test that every value in the sample data is in the Choropleth
                     FCC_Global.assert.notEqual(uniqueFipsFromChoropleth.indexOf(educationDataFips[j]), -1, "Choropleth does not contain all fips from sample data ")
@@ -101,7 +101,7 @@ export default function createChoroplethTests() {
                 for (var i = 0; i < rects.length; i++) {
                     var rectColor = rects[i].style.fill || rects[i].getAttribute('fill');
 
-                    // if the current color isn't in the uniqueColors arr, push it 
+                    // if the current color isn't in the uniqueColors arr, push it
                     if (uniqueColors.indexOf(rectColor) === -1) {
                         uniqueColors.push(rectColor);
                     }
@@ -125,7 +125,7 @@ export default function createChoroplethTests() {
 
 			    // promise is used to prevent test from ending prematurely
 			    return new Promise((resolve, reject) => {
-			        // timeout is used to accomodate tooltip transitions
+			        // timeout is used to accommodate tooltip transitions
 			        setTimeout(_ => {
 			            if (FCC_Global.getToolTipStatus(tooltip) !== 'visible') {
 			                reject(new Error('Tooltip should be visible when mouse is on an area'))

--- a/src/project-tests/drum-machine-tests.js
+++ b/src/project-tests/drum-machine-tests.js
@@ -27,7 +27,7 @@ export default function createDrumMachineTests() {
                 function() {
                     FCC_Global.assert.isNotNull(document.getElementById("drum-machine"));
                     FCC_Global.assert(
-                        document.querySelectorAll(`#drum-machine div, #drum-machine .drum-pad, #drum-machine #display, 
+                        document.querySelectorAll(`#drum-machine div, #drum-machine .drum-pad, #drum-machine #display,
           #drum-machine .clip`).length,
                         'The #drum-machine element must contain other elements '
                     );
@@ -39,7 +39,7 @@ export default function createDrumMachineTests() {
 
             it('3. Within #drum-machine I can see 9 clickable "drum pad" elements, each with a class name of "drum-pad", ' +
                 'a unique id that describes the audio clip the drum pad will be set up to trigger, and an inner text that ' +
-                'corresponds to one of the following keys on the keyboard: Q, W, E, A, S. D, Z, X, C.',
+                'corresponds to one of the following keys on the keyboard: Q, W, E, A, S, D, Z, X, C.',
                 function() {
                     // using .isAtLeast() and .includeMembers() in this challenge so that users have the freedom to add more than 9 drum pads
                     let drumPadInnerText = [];

--- a/src/project-tests/heat-map-tests.js
+++ b/src/project-tests/heat-map-tests.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-// HEAT MAP TESTS: 
+// HEAT MAP TESTS:
 export default function createHeatMapTests() {
 
     describe('#HeatMapTests', function() {
@@ -31,7 +31,7 @@ export default function createHeatMapTests() {
                 for (var i = 0; i < cells.length; i++) {
                     var cellColor = cells[i].style.fill || cells[i].getAttribute('fill');
 
-                    // if the current color isn't in the uniqueColors arr, push it 
+                    // if the current color isn't in the uniqueColors arr, push it
                     if (uniqueColors.indexOf(cellColor) === -1) {
                         uniqueColors.push(cellColor);
                     }
@@ -93,7 +93,7 @@ export default function createHeatMapTests() {
                 const cellsCollection = document.querySelectorAll('.cell');
                 FCC_Global.assert.isAbove(cellsCollection.length, 0, "Could not find any elements with a class=\"cell\" ");
 
-                //convert to array    
+                //convert to array
                 const cells = [].slice.call(cellsCollection);
                 const sortedCells = cells.sort(function(a, b) {
                     return a.getAttribute("data-month") - b.getAttribute("data-month");
@@ -109,7 +109,7 @@ export default function createHeatMapTests() {
                 const cellsCollection = document.querySelectorAll('.cell');
                 FCC_Global.assert.isAbove(cellsCollection.length, 0, "Could not find any elements with a class=\"cell\" ");
 
-                //convert to array    
+                //convert to array
                 const cells = [].slice.call(cellsCollection);
                 const sortedCells = cells.sort(function(a, b) {
                     return a.getAttribute("data-year") - b.getAttribute("data-year");
@@ -169,7 +169,7 @@ export default function createHeatMapTests() {
 
                 // promise is used to prevent test from ending prematurely
                 return new Promise((resolve, reject) => {
-                    // timeout is used to accomodate tooltip transitions
+                    // timeout is used to accommodate tooltip transitions
                     setTimeout(_ => {
                         if (FCC_Global.getToolTipStatus(tooltip) !== 'visible') {
                             reject(new Error('Tooltip should be visible when mouse is on a cell'))

--- a/src/project-tests/markdown-previewer-tests.js
+++ b/src/project-tests/markdown-previewer-tests.js
@@ -19,7 +19,7 @@ export default function createMarkdownPreviewerTests() {
             } else {
                 // jQUERY OR JAVASCRIPT
                 const eventJS = new Event('keyup', { bubbles: true } ); // must be keyup to live preview
-                editor.dispatchEvent(eventJS) 
+                editor.dispatchEvent(eventJS)
             }
         }
 
@@ -62,7 +62,7 @@ export default function createMarkdownPreviewerTests() {
                     triggerChange(markdownOnLoad);
                     const markdown = editor.value;
 
-                    FCC_Global.assert.notStrictEqual(markdown.search(/#\s.+/), -1, 'write some markdown representing an <h1> '); // h1  
+                    FCC_Global.assert.notStrictEqual(markdown.search(/#\s.+/), -1, 'write some markdown representing an <h1> '); // h1
                     FCC_Global.assert.notStrictEqual(markdown.search(/##\s.+/), -1, 'write some markdown representing an <h2> '); // h2
                     FCC_Global.assert.notStrictEqual(markdown.search(/\[.+\]\(.+\..+\)/), -1, 'write some markdown representing an <a> '); // link
                     FCC_Global.assert.notStrictEqual(markdown.search(/`.+`/), -1, 'write some markdown representing inline <code> '); // inline code
@@ -70,7 +70,7 @@ export default function createMarkdownPreviewerTests() {
                     FCC_Global.assert.notStrictEqual(markdown.search(/(?:-|\d\.)\s[^|\s-*].+/), -1, 'write some markdown representing an <li> item '); // ol or ul list item
                     FCC_Global.assert.notStrictEqual(markdown.search(/>\s.+/), -1, 'write some markdown representing an <h1> '); // blockquote
                     FCC_Global.assert.notStrictEqual(markdown.search(/!\[.*\]\(.+\..+\)/), -1, 'write some markdown representing an <h1> '); // image
-                    FCC_Global.assert.notStrictEqual(markdown.search(/(\*\*|__).+\1/), -1, 'write some markdown representing an <h1> '); // bold text        
+                    FCC_Global.assert.notStrictEqual(markdown.search(/(\*\*|__).+\1/), -1, 'write some markdown representing an <h1> '); // bold text
                 });
 
             it('7. When my markdown previewer first loads, the default markdown in the #editor field should be rendered as HTML in the #preview element', function() {
@@ -89,7 +89,7 @@ export default function createMarkdownPreviewerTests() {
                     FCC_Global.assert.isAtLeast(document.querySelectorAll('#preview img').length, 1, '#preview does not contain at least one <img> ');
                     FCC_Global.assert.isAtLeast(document.querySelectorAll('#preview strong').length, 1, '#preview does not contain at least one <strong> ');
 
-                    // then check a couple of elements to make sure the present elements 
+                    // then check a couple of elements to make sure the present elements
                     //are actually the ones represented by the markdown:
 
                     // find matching H1 element
@@ -100,7 +100,7 @@ export default function createMarkdownPreviewerTests() {
                     });
                     FCC_Global.assert.isAtLeast(h1Match.length, 1, '#preview does not contain the H1 element represented by the markdown in the #editor field with the inner text ' + h1Text + ' ');
 
-                    // find mathcing H2 element 
+                    // find matching H2 element 
                     const h2Text = /##\s.*/.exec(markdown)[0].slice(3);
                     const h2Match = [];
                     document.querySelectorAll('#preview h2').forEach(h2 => {

--- a/src/project-tests/pomodoro-clock-tests.js
+++ b/src/project-tests/pomodoro-clock-tests.js
@@ -51,7 +51,7 @@ export default function createPomodoroClockTests() {
     }
 
     // We "Hack" the global setTimeout and setInterval functions so time elapses faster (delay is forced to 30ms)
-    // Note: we should consider putting these hacks in the beforeEach function so every timed test can be done in less time   
+    // Note: we should consider putting these hacks in the beforeEach function so every timed test can be done in less time
     // The problem is that we still don't know if it's acceptable to use this hack, because it implies forcing the campers to use setTimeout and setInterval functions to measure time in their pomodoro.
     const savedSetTimeout = window.setTimeout;
     const savedSetInterval = window.setInterval;
@@ -128,8 +128,8 @@ export default function createPomodoroClockTests() {
             });
 
             /*For now just confirm that element exists. Will test contents when timer is running later.
-            If we force an initial value of 25:00, campers will then have to make the session length 
-            buttons also update the intial value to reflect the change, which is complicated and not 
+            If we force an initial value of 25:00, campers will then have to make the session length
+            buttons also update the initial value to reflect the change, which is complicated and not
             necessarily needed. No time needs to be shown here until the timer is actually running.*/
             it("8. I can see an element with corresponding id=\"time-left\".", function() {
                 FCC_Global.assert.isNotNull(document.getElementById("time-left"));
@@ -208,21 +208,21 @@ export default function createPomodoroClockTests() {
 
             it('16. I should not be able to set a session or break length to <= 0.', function() {
                 clickButtonsById(Array(10).fill(_break_min));
-                FCC_Global.assert.strictEqual(document.getElementById("break-length").innerHTML, "1", 'Value in elment with ' +
+                FCC_Global.assert.strictEqual(document.getElementById("break-length").innerHTML, "1", 'Value in element with ' +
                     'id of "break-length" is less than 1.');
                 resetTimer();
                 clickButtonsById(Array(30).fill(_sesh_min));
-                FCC_Global.assert.strictEqual(document.getElementById("session-length").innerHTML, "1", 'Value in elment with ' +
+                FCC_Global.assert.strictEqual(document.getElementById("session-length").innerHTML, "1", 'Value in element with ' +
                     'id of "session-length" is less than 1.');
             });
 
             it('17. I should not be able to set a session or break length to > 60.', function() {
                 clickButtonsById(Array(60).fill(_break_plus));
-                FCC_Global.assert.strictEqual(document.getElementById("break-length").innerHTML, "60", 'Value in elment with ' +
+                FCC_Global.assert.strictEqual(document.getElementById("break-length").innerHTML, "60", 'Value in element with ' +
                     'id of "break-length" is greater than 60.');
                 resetTimer();
                 clickButtonsById(Array(40).fill(_sesh_plus));
-                FCC_Global.assert.strictEqual(document.getElementById("session-length").innerHTML, "60", 'Value in elment with ' +
+                FCC_Global.assert.strictEqual(document.getElementById("session-length").innerHTML, "60", 'Value in element with ' +
                     'id of "session-length" is greater than 60.');
             });
 
@@ -306,7 +306,7 @@ export default function createPomodoroClockTests() {
             it('22. When a session countdown reaches zero (NOTE: timer MUST reach 00:00), and a new countdown begins, the element with the id of "timer-label" should display a string indicating a break has begun.', function() {
                 this.timeout(5000);
                 // We "Hack" the global setTimeout and setInterval functions so time elapses faster (delay is forced to 30ms)
-                // Note: we should consider putting these hacks in the beforeEach function so every timed test can be done in less time   
+                // Note: we should consider putting these hacks in the beforeEach function so every timed test can be done in less time
                 // The problem is that we still don't know if it's acceptable to use this hack, because it implies forcing the campers to use setTimeout and setInterval functions to measure time in their pomodoro.
                 hackGlobalTimerFunctions();
                 // we decrement session time to the minimum (1 minute)
@@ -315,7 +315,7 @@ export default function createPomodoroClockTests() {
                 clickButtonsById([_start_stop]);
                 return new Promise((resolve, reject) => {
                     // 2 approaches here, we can either
-                    // - watch for modifications on the time label and wait till it reaches zero, then we wait some more and then check the "Break" label. 
+                    // - watch for modifications on the time label and wait till it reaches zero, then we wait some more and then check the "Break" label.
                     const timeLeft = document.getElementById("time-left");
                     // Save label to test that it has changed below
                     let sessionLabel = document.getElementById("timer-label").innerHTML;
@@ -355,8 +355,8 @@ export default function createPomodoroClockTests() {
                 return new Promise((resolve, reject) => {
                     const timeLeft = document.getElementById("time-left");
                     let shouldBeInBreak = false;
-                    // Since not requiring specific labels, save the 'session' label to a variable, then test 
-                    // within observer funciton that label has changed to know when in break
+                    // Since not requiring specific labels, save the 'session' label to a variable, then test
+                    // within observer function that label has changed to know when in break
                     let sessionLabel = document.getElementById("timer-label").innerHTML;
                     const observer = observeElement("time-left", modType => {
                         if (timeLeft.innerHTML === "00:00") {

--- a/src/project-tests/product-landing-page-tests.js
+++ b/src/project-tests/product-landing-page-tests.js
@@ -59,7 +59,7 @@ export default function createProductLandingPageTests() {
             it('9. The #email input field should have placeholder text to let the user know what the field is for.', function() {
                 FCC_Global.assert.isNotNull(document.getElementById("email"), '#email is not defined ');
                 FCC_Global.assert.strictEqual(document.getElementById("email").hasAttribute('placeholder'), true,
-                    'The input field does not have placehoder text ');
+                    'The input field does not have placeholder text ');
                 FCC_Global.assert.isAbove(document.getElementById("email").getAttribute('placeholder').length, 0,
                     'The placeholder attribute should have some text ');
             });
@@ -133,8 +133,8 @@ export default function createProductLandingPageTests() {
                         }
                     }
                 }
-                // our test suite uses a display of flex, so we need to count how many times its used 
-                // and confirm that its more than once. If we just detect one instance, its ours. 
+                // our test suite uses a display of flex, so we need to count how many times its used
+                // and confirm that its more than once. If we just detect one instance, its ours.
                 FCC_Global.assert.isAbove(flexCount.length, 1, 'We do not detect a display property set to flex or inline-flex anywhere in your CSS ')
             });
 

--- a/src/project-tests/scatter-plot-tests.js
+++ b/src/project-tests/scatter-plot-tests.js
@@ -42,7 +42,7 @@ export default function createScatterPlotTests() {
                 const MAX_X_VALUE = MAX_YEAR;
 
                 const dotsCollection = document.getElementsByClassName('dot');
-                //convert to array    
+                //convert to array
                 const dots = [].slice.call(dotsCollection);
                 FCC_Global.assert.isAbove(dots.length, 0, 'there are no elements with the class of "dot" ');
                 dots.forEach(dot => {
@@ -59,7 +59,7 @@ export default function createScatterPlotTests() {
 
             it('7. The data-xvalue and its corresponding dot should align with the corresponding point/value on the x-axis.', function() {
                 const dotsCollection = document.getElementsByClassName('dot');
-                //convert to array    
+                //convert to array
                 const dots = [].slice.call(dotsCollection);
                 FCC_Global.assert.isAbove(dots.length, 0, 'there are no elements with the class of "dot" ');
                 //sort the dots based on xvalue in ascending order
@@ -75,7 +75,7 @@ export default function createScatterPlotTests() {
 
             it('8. The data-yvalue and its corresponding dot should align with the corresponding point/value on the y-axis.', function() {
                 const dotsCollection = document.getElementsByClassName('dot');
-                //convert to array    
+                //convert to array
                 const dots = [].slice.call(dotsCollection);
                 FCC_Global.assert.isAbove(dots.length, 0, 'there are no elements with the class of "dot" ');
                 //sort the dots based on yvalue in ascending order
@@ -154,7 +154,7 @@ export default function createScatterPlotTests() {
 
                 // promise is used to prevent test from ending prematurely
                 return new Promise((resolve, reject) => {
-                    // timeout is used to accomodate tooltip transitions
+                    // timeout is used to accommodate tooltip transitions
                     setTimeout(_ => {
                         if (FCC_Global.getToolTipStatus(tooltip) !== 'visible') {
                             reject('Tooltip should be visible when mouse is on a dot ');

--- a/src/project-tests/technical-docs-tests.js
+++ b/src/project-tests/technical-docs-tests.js
@@ -6,15 +6,15 @@ export default function createTechnicalDocsPageTests() {
 
     describe("Technical Documentation Page tests", function() {
         describe('#Content', function() {
-            it('1. I can see an <article> element with a corresponding id="main-doc", which contains the ' +
+            it('1. I can see a <main> element with a corresponding id="main-doc", which contains the ' +
                 'page\'s main content (technical documentation).',
                 function() {
                     FCC_Global.assert.isNotNull(document.getElementById('main-doc'), "There is no element with an id of 'main-doc' ");
-                    FCC_Global.assert.strictEqual(document.getElementById('main-doc').nodeName, "ARTICLE",
-                        "The 'main-doc' element should be an <article> ");
+                    FCC_Global.assert.strictEqual(document.getElementById('main-doc').nodeName, "MAIN",
+                        "The 'main-doc' element should be a <main> ");
                 });
 
-            it('2. Within the #main-doc <article> element, I can see several <section> elements, each with a class ' +
+            it('2. Within the #main-doc <main> element, I can see several <section> elements, each with a class ' +
                 'of "main-section". There should be a minimum of 5.',
                 function() {
                     let classQty = classArray('main-section').length;
@@ -61,18 +61,18 @@ export default function createTechnicalDocsPageTests() {
                 FCC_Global.assert.isAtLeast(document.querySelectorAll('.main-section p').length, 10, "There are not at least 10 <p> " +
                     "elements throughout all of the elements with the class of 'main-section' ");
                 // WANTED THE TEST TO BE AS FOLLOWS BUT COULD NOT FIND A WAY TO TEST FOR ELEMENTS WITH CLASS OF MAIN-SECTION
-                // CONTAINING <P> ELEMENTS AT AN ARBITRARY DEPTH OF NESTING (WIHTOUT ADDITIONAL EXTERNAL DEPENDENCIES):
+                // CONTAINING <P> ELEMENTS AT AN ARBITRARY DEPTH OF NESTING (WITHOUT ADDITIONAL EXTERNAL DEPENDENCIES):
                 // Each "main-section" should contain at least one <p> element with textual content.
             });
 
             it('6. The .main-section elements should contain at least 5 <code> elements total (not each).', function() {
                 FCC_Global.assert.isAtLeast(document.querySelectorAll('.main-section code').length, 5, "There are not at least 5 <code> " +
-                    "elements throughout all of the elemnts with the class of 'main-section' ");
+                    "elements throughout all of the elements with the class of 'main-section' ");
             });
 
             it('7. The .main-section elements should contain at least 5 <li> items total (not each).', function() {
                 FCC_Global.assert.isAtLeast(document.querySelectorAll('.main-section li').length, 5, "There are not " +
-                    "at least 5 <li> elements throughout all of the elemnts with the class of 'main-section' ");
+                    "at least 5 <li> elements throughout all of the elements with the class of 'main-section' ");
             });
 
             it('8. I can see a <nav> element with a corresponding id="navbar".', function() {


### PR DESCRIPTION
Review of the User Stories text, fixes a few typos in the project-tests files. Also, after discussion with @no-stack-dub-sack, this changes the requirement in Test 1 of the Technical Docs project to use a `main` tag instead of an `article` tag.