### PR TITLE
Fix portfolio layout test 2: now properly measures viewport height

### DIFF
--- a/build/bundle.js
+++ b/build/bundle.js
@@ -20114,7 +20114,7 @@ var FCC_Global =
 	            });
 
 	            it('2. The height of the welcome section should be equal to the height of the viewport.', function () {
-	                FCC_Global.assert.equal(document.getElementById('welcome-section').offsetHeight, document.documentElement.clientHeight, 'The height of #welcome-section is not equal to the height of the viewport ');
+	                FCC_Global.assert.equal(document.getElementById('welcome-section').offsetHeight, window.innerHeight, 'The height of #welcome-section is not equal to the height of the viewport ');
 	            });
 
 	            it('3. The navbar should always be at the top of the viewport.', function () {

--- a/src/project-tests/portfolio-tests.js
+++ b/src/project-tests/portfolio-tests.js
@@ -107,7 +107,7 @@ export default function createPortfolioTests() {
             });
 
             it('2. The height of the welcome section should be equal to the height of the viewport.', function() {
-                FCC_Global.assert.equal(document.getElementById('welcome-section').offsetHeight, document.documentElement.clientHeight,
+                FCC_Global.assert.equal(document.getElementById('welcome-section').offsetHeight, window.innerHeight,
                     'The height of #welcome-section is not equal to the height of the viewport ');
             });
 


### PR DESCRIPTION
#### Pre-Submission Checklist
- [x] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] Your changes have been tested either locally or using a newly created CDN based on your fork's testable-projects-fcc/build/bundle.js file
- [x] Working changes have been added to the build by running `npm run build`

#### Type of Change
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXX with an issue no): Closes #48

#### Description
New test uses `window.innerHeight` instead of `document.documentElement.clientHeight` in order to accurately measure the height of the viewport, even when there is a horizontal scrollbar. The old solution subtracted the height of the scrollbar, which made the test inaccurate.
