### PR TITLE
Added a workaround for a bug with Chrome for CSS position:sticky

### DIFF
--- a/build/bundle.js
+++ b/build/bundle.js
@@ -20153,12 +20153,20 @@ var FCC_Global =
 	                FCC_Global.assert.equal(document.getElementById('welcome-section').offsetHeight, window.innerHeight, 'The height of #welcome-section is not equal to the height of the viewport ');
 	            });
 
-	            it('3. The navbar should always be at the top of the viewport.', function () {
+	            it('3. The navbar should always be at the top of the viewport.', function (done) {
 	                var navbar = document.getElementById('navbar');
-	                FCC_Global.assert.approximately(navbar.getBoundingClientRect().top, 0, 15), 'Navbar\'s parent should be body and it should be at the top of the viewport ';
+	                FCC_Global.assert.approximately(navbar.getBoundingClientRect().top, 0, 15, 'Navbar\'s parent should be body and it should be at the top of the viewport ');
 	                window.scroll(0, 500);
-	                FCC_Global.assert.approximately(navbar.getBoundingClientRect().top, 0, 15, 'Navbar should be at the top of the viewport even after scrolling ');
-	                window.scroll(0, 0);
+
+	                // This timeout is to allow page layout to happen after the window.scroll. Without it
+	                // the getBoundingClientRect can sometimes report the wrong value while the page is
+	                // still laying out, when using CSS position:sticky.
+	                // This is apparently a bug with Chrome https://bugs.chromium.org/p/chromium/issues/detail?id=672457
+	                setTimeout(function () {
+	                    FCC_Global.assert.approximately(navbar.getBoundingClientRect().top, 0, 15, 'Navbar should be at the top of the viewport even after scrolling ');
+	                    window.scroll(0, 0);
+	                    done();
+	                }, 1);
 	            });
 	        }); // END #Layout
 	    }); // END #PortfolioTests

--- a/src/project-tests/portfolio-tests.js
+++ b/src/project-tests/portfolio-tests.js
@@ -111,12 +111,21 @@ export default function createPortfolioTests() {
                     'The height of #welcome-section is not equal to the height of the viewport ');
             });
 
-            it('3. The navbar should always be at the top of the viewport.', function() {
+            it('3. The navbar should always be at the top of the viewport.', function(done) {
                 const navbar = document.getElementById('navbar');
-                FCC_Global.assert.approximately(navbar.getBoundingClientRect().top, 0, 15), 'Navbar\'s parent should be body and it should be at the top of the viewport ';
+                FCC_Global.assert.approximately(navbar.getBoundingClientRect().top, 0, 15, 'Navbar\'s parent should be body and it should be at the top of the viewport ');
                 window.scroll(0, 500);
-                FCC_Global.assert.approximately(navbar.getBoundingClientRect().top, 0, 15, 'Navbar should be at the top of the viewport even after scrolling ');
-                window.scroll(0, 0);
+
+                // This timeout is to allow page layout to happen after the window.scroll. Without it
+                // the getBoundingClientRect can sometimes report the wrong value while the page is
+                // still laying out, when using CSS position:sticky.
+                // This is apparently a bug with Chrome https://bugs.chromium.org/p/chromium/issues/detail?id=672457
+                setTimeout(function () {
+                  FCC_Global.assert.approximately(navbar.getBoundingClientRect().top, 0, 15, 'Navbar should be at the top of the viewport even after scrolling ');
+                  window.scroll(0, 0);
+                  done();
+                }, 1);
+
             });
 
         }); // END #Layout


### PR DESCRIPTION
<!-- freeCodeCamp Testable Projects Pull Request Template -->

<!-- IMPORTANT: PRs against this repo should follow the general guidelines laid out for FCC's main repo as well as the guidlines specific to this repo -->
<!-- Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md && https://github.com/freeCodeCamp/testable-projects-fcc/blob/master/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] Your changes have been tested either locally or using a newly created CDN based on your fork's testable-projects-fcc/build/bundle.js file
- [x] Working changes have been added to the build by running `npm run build`

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
- [x] Tested changes locally.
- [x] Closes currently open issue (replace XXX with an issue no): Closes #97 

#### Description
<!-- Describe your changes in detail -->
This test was failing due to [a documented bug in Chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=672457). 

In short, CSS `position: sticky` can cause `getBoundingClientRect()` to report the wrong values if executed immediately after `window.scroll`. The workaround is to use `setTimeout` to yield to the browser to allow page layout to complete before running `getBoundingClientRect()`.