### PR TITLE
add spacing in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@
 <!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
 <!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
 <!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
 - [ ] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
 - [ ] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
 - [ ] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
@@ -17,6 +18,7 @@
 
 #### Type of Change
 <!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->
+
 - [ ] Small bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds new functionality)
 - [ ] Breaking change (fix or feature that would change existing functionality)
@@ -25,8 +27,10 @@
 #### Checklist:
 <!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
 <!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->
+
 - [ ] Tested changes locally.
-- [ ] Closes currently open issue (replace XXX with an issue no): Closes #XXX
+<!-- replace XXX with an issue # -->
+- [ ] Closes currently open issue: Closes #XXX
 
 #### Description
 <!-- Describe your changes in detail -->


### PR DESCRIPTION
Added more spacing in pull request template, so little easier to differentiate between the comments and the checklist items

<!-- freeCodeCamp Testable Projects Pull Request Template -->

<!-- IMPORTANT: PRs against this repo should follow the general guidelines laid out for FCC's main repo as well as the guidlines specific to this repo -->
<!-- Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md && https://github.com/freeCodeCamp/testable-projects-fcc/blob/master/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).

