### PR TITLE
scatterplot axis g element, x-axis Date or integer, ensure legend text

### DIFF
--- a/build/bundle.js
+++ b/build/bundle.js
@@ -21003,7 +21003,7 @@ var FCC_Global =
 
 	      it('2. I can see an x-axis that has a corresponding id="x-axis".', function () {
 	        FCC_Global.assert.isNotNull(document.getElementById('x-axis'), 'There should be an element with id="x-axis" ');
-	        FCC_Global.assert.isAbove(document.querySelectorAll('#x-axis g').length, 0, 'x-axis should be a <g> SVG element ');
+	        FCC_Global.assert.isAbove(document.querySelectorAll('g#x-axis').length, 0, 'x-axis should be a <g> SVG element ');
 	      });
 
 	      it('3. I can see a y-axis that has a corresponding id="y-axis".', function () {
@@ -21012,7 +21012,7 @@ var FCC_Global =
 	      });
 
 	      it('4. I can see dots, that each have a class of "dot", which represent\n      the data being plotted.', function () {
-	        FCC_Global.assert.isAbove(document.querySelectorAll('.dot').length, 0, 'Could not find any circles with class="dot" ');
+	        FCC_Global.assert.isAbove(document.querySelectorAll('circle.dot').length, 0, 'Could not find any <circle> SVG elements with class="dot" ');
 	      });
 
 	      it('5. Each dot should have the properties "data-xvalue" and\n      "data-yvalue" containing their corresponding x and y values.', function () {
@@ -21025,7 +21025,7 @@ var FCC_Global =
 	        }
 	      });
 
-	      it('6. The data-xvalue and data-yvalue of each dot should be within the\n      range of the actual data.', function () {
+	      it('6. The data-xvalue and data-yvalue of each dot should be within the\n      range of the actual data and in the correct data format. For data-xvalue, \n      integers (full years) or Date objects are acceptable for test evaluation. \n      For data-yvalue (minutes), use Date objects. ', function () {
 	        var MIN_X_VALUE = MIN_YEAR;
 	        var MAX_X_VALUE = MAX_YEAR;
 
@@ -21033,10 +21033,11 @@ var FCC_Global =
 	        // convert to array
 	        var dots = [].slice.call(dotsCollection);
 	        FCC_Global.assert.isAbove(dots.length, 0, 'there are no elements with the class of "dot" ');
-	        dots.forEach(function (dot) {
 
-	          FCC_Global.assert.isAtLeast(dot.getAttribute('data-xvalue'), MIN_X_VALUE, 'The data-xvalue of a dot is below the range of the actual data ');
-	          FCC_Global.assert.isAtMost(dot.getAttribute('data-xvalue'), MAX_X_VALUE, 'The data-xvalue of a dot is above the range of the actual data ');
+	        dots.forEach(function (dot) {
+	          var xYear = new Date(dot.getAttribute('data-xvalue'));
+	          FCC_Global.assert.isAtLeast(xYear.getFullYear(), MIN_X_VALUE, 'The data-xvalue of a dot is below the range of the actual data ');
+	          FCC_Global.assert.isAtMost(xYear.getFullYear(), MAX_X_VALUE, 'The data-xvalue of a dot is above the range of the actual data ');
 
 	          // compare just the minutes for a good approximation
 	          var yDate = new Date(dot.getAttribute('data-yvalue'));
@@ -21119,6 +21120,7 @@ var FCC_Global =
 	        var MIN_YEAR = 1994;
 	        var MAX_YEAR = 2016;
 	        FCC_Global.assert.isAbove(xAxisTickLabels.length, 0, 'Could not find tick labels on the x axis ');
+
 	        xAxisTickLabels.forEach(function (label) {
 	          FCC_Global.assert.isAtLeast(label.textContent, MIN_YEAR, 'x axis labels are below the range of the actual data ');
 	          FCC_Global.assert.isAtMost(label.textContent, MAX_YEAR, 'x axis labels are above the range of the actual data ');
@@ -21140,8 +21142,16 @@ var FCC_Global =
 	        });
 	      });
 
-	      it('13. I can see a legend that has id="legend".', function () {
+	      it('13. I can see a legend containing descriptive text that has \n      id="legend".', function () {
 	        FCC_Global.assert.isNotNull(document.getElementById('legend'), 'There should be an element with id="legend" ');
+	        //A legend may be built with D3 svg <text> elements or with plain html
+	        var legendText;
+	        if (document.querySelector('#legend text') !== null) {
+	          legendText = document.querySelector('#legend text').innerHTML;
+	        } else {
+	          legendText = document.getElementById('legend').innerText;
+	        }
+	        FCC_Global.assert.isNotNull(legendText, 'The legend should contain text ');
 	      });
 	    });
 

--- a/src/project-tests/scatter-plot-tests.js
+++ b/src/project-tests/scatter-plot-tests.js
@@ -35,7 +35,7 @@ export default function createScatterPlotTests() {
           'There should be an element with id="x-axis" '
         );
         FCC_Global.assert.isAbove(
-          document.querySelectorAll('#x-axis g').length,
+          document.querySelectorAll('g#x-axis').length,
           0,
           'x-axis should be a <g> SVG element '
         );
@@ -58,9 +58,9 @@ export default function createScatterPlotTests() {
       the data being plotted.`,
       function() {
         FCC_Global.assert.isAbove(
-          document.querySelectorAll('.dot').length,
+          document.querySelectorAll('circle.dot').length,
           0,
-          'Could not find any circles with class="dot" '
+          'Could not find any <circle> SVG elements with class="dot" '
         );
       });
 
@@ -87,7 +87,9 @@ export default function createScatterPlotTests() {
       });
 
       it(`6. The data-xvalue and data-yvalue of each dot should be within the
-      range of the actual data.`,
+      range of the actual data and in the correct data format. For data-xvalue, 
+      integers (full years) or Date objects are acceptable for test evaluation. 
+      For data-yvalue (minutes), use Date objects. `,
       function() {
         const MIN_X_VALUE = MIN_YEAR;
         const MAX_X_VALUE = MAX_YEAR;
@@ -100,15 +102,16 @@ export default function createScatterPlotTests() {
           0,
           'there are no elements with the class of "dot" '
         );
+        
         dots.forEach(dot => {
-
+          var xYear = new Date(dot.getAttribute('data-xvalue'));
           FCC_Global.assert.isAtLeast(
-            dot.getAttribute('data-xvalue'),
+            xYear.getFullYear(),
             MIN_X_VALUE,
             'The data-xvalue of a dot is below the range of the actual data '
           );
           FCC_Global.assert.isAtMost(
-            dot.getAttribute('data-xvalue'),
+            xYear.getFullYear(),
             MAX_X_VALUE,
             'The data-xvalue of a dot is above the range of the actual data '
           );
@@ -266,6 +269,7 @@ export default function createScatterPlotTests() {
           0,
           'Could not find tick labels on the x axis '
         );
+        
         xAxisTickLabels.forEach(label => {
           FCC_Global.assert.isAtLeast(
             label.textContent,
@@ -309,12 +313,24 @@ export default function createScatterPlotTests() {
         });
       });
 
-      it('13. I can see a legend that has id="legend".',
+      it(`13. I can see a legend containing descriptive text that has 
+      id="legend".`,
       function() {
         FCC_Global.assert.isNotNull(
           document.getElementById('legend'),
           'There should be an element with id="legend" '
         );
+        //A legend may be built with D3 svg <text> elements or with plain html
+        var legendText;
+        if (document.querySelector('#legend text') !== null) {
+          legendText = document.querySelector('#legend text').innerHTML
+        } else {
+          legendText = document.getElementById('legend').innerText
+        }
+        FCC_Global.assert.isNotNull(
+          legendText,
+          'The legend should contain text '
+        )
       });
     });
 


### PR DESCRIPTION
<!-- freeCodeCamp Testable Projects Pull Request Template -->

<!-- IMPORTANT: PRs against this repo should follow the general guidelines laid out for FCC's main repo as well as the guidlines specific to this repo -->
<!-- Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md && https://github.com/freeCodeCamp/testable-projects-fcc/blob/master/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] Your changes have been tested either locally or using a newly created CDN based on your fork's testable-projects-fcc/build/bundle.js file
- [x] Working changes have been added to the build by running `npm run build`

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->

- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->

- [x] Tested changes locally.
<!-- replace XXX with an issue # -->
- [x] Closes currently open issue: Closes #124

#### Description
<!-- Describe your changes in detail -->

Test 2 was querying the number of axis .tick elements, and not the axis `<g>` element as described. Test 6 is modified to allow Date objects as years (data-xvalue) and mention data formats. Test 13 now includes a query for text inside the legend. All other tests are working as described. 