### PR TITLE
markdown restore default configuration of textarea element after tests

### DIFF
--- a/build/bundle.js
+++ b/build/bundle.js
@@ -19073,7 +19073,7 @@ var FCC_Global =
 /* 44 */
 /***/ (function(module, exports, __webpack_require__) {
 
-	exports = module.exports = __webpack_require__(45)(undefined);
+	exports = module.exports = __webpack_require__(45)(false);
 	// imports
 	exports.push([module.id, "@import url(https://fonts.googleapis.com/css?family=Noto+Sans);", ""]);
 
@@ -19844,6 +19844,16 @@ var FCC_Global =
 	      editor.dispatchEvent(eventJS);
 	      return;
 	    }
+	    // We need to undo the configuration set in triggerChange after running
+	    // tests. The configuration was added to allow dispatchEvent for
+	    // programmatic value change in React 15.6
+	    // See https://stackoverflow.com/a/7144252/3530394
+	    after(function () {
+	      // remove the value attribute in order to remove the configuration
+	      delete editor.value;
+	      // restore default markdown text
+	      editor.value = markdownOnLoad;
+	    });
 
 	    describe('#Technology Stack', function () {
 	      it(_sharedTestStrings.frontEndLibrariesStack, function () {

--- a/src/project-tests/markdown-previewer-tests.js
+++ b/src/project-tests/markdown-previewer-tests.js
@@ -61,6 +61,16 @@ export default function createMarkdownPreviewerTests() {
       return;
 
     }
+    // We need to undo the configuration set in triggerChange after running
+    // tests. The configuration was added to allow dispatchEvent for
+    // programmatic value change in React 15.6
+    // See https://stackoverflow.com/a/7144252/3530394
+    after(function() {
+      // remove the value attribute in order to remove the configuration
+      delete editor.value;
+      // restore default markdown text
+      editor.value = markdownOnLoad;
+    });
 
     describe('#Technology Stack', function() {
       it(frontEndLibrariesStack, function() {


### PR DESCRIPTION
<!-- freeCodeCamp Testable Projects Pull Request Template -->

<!-- IMPORTANT: PRs against this repo should follow the general guidelines laid out for FCC's main repo as well as the guidlines specific to this repo -->
<!-- Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md && https://github.com/freeCodeCamp/testable-projects-fcc/blob/master/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] Your changes have been tested either locally or using a newly created CDN based on your fork's testable-projects-fcc/build/bundle.js file
- [x] Working changes have been added to the build by running `npm run build`

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->

- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->

- [x] Tested changes locally.
<!-- replace XXX with an issue # -->
- [x] Closes currently open issue: Closes #286

#### Description
<!-- Describe your changes in detail -->
Since #223, the editor `<textarea>` stays configured for programmatic value change after tests, rendering the markdown editor non-functional after the tests run. This PR deletes the editor.value attribute after the tests run in order to re-set the default configuration.