### PR TITLE
Technical Documentation: toUpperCase for comparing headers and nav-link text

### DIFF
--- a/build/bundle.js
+++ b/build/bundle.js
@@ -22123,10 +22123,10 @@ var FCC_Global =
 	      it(reqNum + '. Each element with the class of "nav-link" should contain\n      text that corresponds to the <header> text within each <section> (e.g. if\n      you have a "Hello world" section/header, your navbar should have an\n      element which contains the text "Hello world").', function () {
 	        _chai.assert.isAbove(classArray('nav-link').length, 0, 'No elements with the class "nav-link" have been defined ');
 	        var headerText = classArray('main-section').map(function (el) {
-	          return el.firstElementChild.innerText.trim();
+	          return el.firstElementChild.innerText.trim().toUpperCase();
 	        });
 	        var linkText = classArray('nav-link').map(function (el) {
-	          return (/[^\n\t\f\r\v]+/.exec(el.innerText)[0]
+	          return (/[^\n\t\f\r\v]+/.exec(el.innerText)[0].toUpperCase()
 	          );
 	        });
 	        // use indexOf instead of matching index for index, in case for some

--- a/src/project-tests/technical-docs-tests.js
+++ b/src/project-tests/technical-docs-tests.js
@@ -284,10 +284,10 @@ export default function createTechnicalDocsPageTests() {
           'No elements with the class "nav-link" have been defined '
         );
         const headerText = classArray('main-section').map((el) =>
-          el.firstElementChild.innerText.trim()
+          el.firstElementChild.innerText.trim().toUpperCase()
         );
         const linkText = classArray('nav-link').map((el) =>
-          (/[^\n\t\f\r\v]+/).exec(el.innerText)[0]
+          (/[^\n\t\f\r\v]+/).exec(el.innerText)[0].toUpperCase()
         );
         // use indexOf instead of matching index for index, in case for some
         // reason they have them out of order


### PR DESCRIPTION
<!-- freeCodeCamp Testable Projects Pull Request Template -->

<!-- IMPORTANT: PRs against this repo should follow the general guidelines laid out for FCC's main repo as well as the guidlines specific to this repo -->
<!-- Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md && https://github.com/freeCodeCamp/testable-projects-fcc/blob/master/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] Your changes have been tested either locally or using a newly created CDN based on your fork's testable-projects-fcc/build/bundle.js file
- [x] Working changes have been added to the build by running `npm run build`

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->

- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->

- [x] Tested changes locally.
<!-- replace XXX with an issue # -->
- [x] Closes currently open issue: Closes #291

#### Description
<!-- Describe your changes in detail -->
the .innerText property was converting values to uppercase. Tested .textContent and it works as a replacement.