### PR TITLE
fix: shapes aligned with ticks test

### DIFF
--- a/src/utils/alignment-D3-support.js
+++ b/src/utils/alignment-D3-support.js
@@ -33,8 +33,6 @@ export function getTickPosition(tick) {
 export function getTickValue(item, dataType) {
   let val = item.querySelector('text').innerHTML;
   switch (dataType) {
-    case null:
-      break;
     case 'minute':
       val = parseInt(val.split(':')[0], 10) +
         (parseInt(val.split(':')[1], 10) / 60);
@@ -54,9 +52,6 @@ export function getTickValue(item, dataType) {
 export function getShapeValue(item, attribute, dataType) {
   let val;
   switch (dataType) {
-    case null:
-      val = item.getAttribute(attribute);
-      break;
     case 'year':
       val = new Date(item.getAttribute(attribute)).getFullYear();
       break;
@@ -77,27 +72,10 @@ export function getShapeValue(item, attribute, dataType) {
 }
 
 export function getShapePosition(item, dimension, positionType) {
-  let half, bounds = item.getBoundingClientRect(),
+  let bounds = item.getBoundingClientRect(),
     pos = ((/y/g).test(dimension) ? bounds.top : bounds.left);
-  switch (positionType) {
-    case 'topLeft':
-      // bar
-      half = 0;
-      break;
-    case 'center':
-      // get either 'width' or 'height' if dimension is 'x', 'cx', 'y', or 'cy'
-      let attr = (/y/g).test(dimension) ? 'height' : 'width';
-      // circle elements have 'r' attributes instead of 'height' or 'width'.
-      // The half variable is for rect elements we want the midpoint from
-      // so item.getAttribute(attr) will be null for circles.
-      half = ( !item.getAttribute(attr) ?
-        0 :
-        parseFloat(item.getAttribute(attr)) / 2
-      );
-      break;
-    default:
-      half = 0;
+  if (positionType === 'center') {
+    pos += ((/y/g).test(dimension) ? bounds.height : bounds.width) / 2;
   }
-  pos += half;
   return pos;
 }

--- a/test/alignment-D3-support.js
+++ b/test/alignment-D3-support.js
@@ -65,6 +65,16 @@ describe('D3 Alignment support tests', function() {
         </rect>`
       );
       const shape = dom.window.document.querySelector('.cell');
+      // We have to mock this for jsdom.
+      const width = 5, height = 33;
+      shape.getBoundingClientRect = () => ({
+        width,
+        height,
+        top: 0,
+        left: 0,
+        right: width,
+        bottom: height
+      });
       const positionX = getShapePosition(shape, 'x', 'center');
       const positionY = getShapePosition(shape, 'y', 'center');
 

--- a/test/alignment-D3.js
+++ b/test/alignment-D3.js
@@ -1,7 +1,8 @@
 // BDD tests for the alignment-D3 module.
 
 import {
-  getShapeValue
+  getShapeValue,
+  getTickValue
 } from '../src/utils/alignment-D3-support';
 
 import {
@@ -76,15 +77,15 @@ describe('D3 Alignment module tests', function() {
   </g>
   <g id="x-axis" transform="translate(0,500)">
     <g class="tick" transform="translate(37.02173913043478,0)">
-      <line y2="6"></line>      
+      <line y2="6"></line>
       <text>1994</text>
     </g>
     <g class="tick" transform="translate(110.06521739130434,0)">
-      <line y2="6"></line>      
+      <line y2="6"></line>
       <text>1996</text>
     </g>
     <g class="tick" transform="translate(183.1086956521739,0)">
-      <line y2="6"></line>      
+      <line y2="6"></line>
       <text>1998</text>
     </g>
   </g>
@@ -121,28 +122,28 @@ describe('D3 Alignment module tests', function() {
   </g>
   <g id="x-axis">
     <g class="tick" transform="translate(110.91666666666666,0)">
-      <line y2="6"></line>      
+      <line y2="6"></line>
       <text>1994</text>
     </g>
     <g class="tick" transform="translate(171.75,0)">
-      <line y2="6"></line>      
+      <line y2="6"></line>
       <text>1996</text>
     </g>
     <g class="tick" transform="translate(232.66666666666666,0)">
-      <line y2="6"></line>      
+      <line y2="6"></line>
       <text>1998</text>
     </g>
   </g>
-  <circle class="dot" r="3" cx="140.83333333333331" cy="400" data-xvalue="1995" 
+  <circle class="dot" r="3" cx="140.83333333333331" cy="400" data-xvalue="1995"
     data-yvalue="Mon Jan 01 1900 00:36:50 GMT-0700 (MST)">
   </circle>
-  <circle class="dot" r="3" cx="201.75" cy="390" data-xvalue="1997" 
+  <circle class="dot" r="3" cx="201.75" cy="390" data-xvalue="1997"
     data-yvalue="Mon Jan 01 1900 00:36:55 GMT-0700 (MST)">
   </circle>
-  <circle class="dot" r="3" cx="110.41666666666666" cy="350" data-xvalue="1994" 
+  <circle class="dot" r="3" cx="110.41666666666666" cy="350" data-xvalue="1994"
     data-yvalue="Mon Jan 01 1900 00:37:15 GMT-0700 (MST)">
   </circle>
-  
+
   <circle class="dot-misaligned" r="6" cx="0"
     cy="355" data-xvalue="1997"
     data-yvalue="Mon Jan 01 1900 00:37:25 GMT-0200 (BRST)">
@@ -168,7 +169,7 @@ describe('D3 Alignment module tests', function() {
         <text x="-9" dy="0.32em">8,000</text>
       </g>
     </g>
-    
+
     <g id="x-axis" transform="translate(60, 400)">
       <g class="tick" transform="translate(35.794117647058826,0)">
         <line y2="6"></line>
@@ -187,17 +188,17 @@ describe('D3 Alignment module tests', function() {
         <text y="9" dy="0.71em">1965</text>
       </g>
     </g>
-    
-    <rect data-date="1947-01-01" data-gdp="243.1" class="bar" 
-      x="0" y="394.6171262185367" width="2.909090909090909" 
+
+    <rect data-date="1947-01-01" data-gdp="243.1" class="bar"
+      x="0" y="394.6171262185367" width="2.909090909090909"
       height="5.382873781463295" transform="translate(60, 0)">
     </rect>
-    <rect data-date="1947-04-01" data-gdp="246.3" class="bar" 
-      x="2.909090909090909" y="394.5462697968967" width="2.909090909090909" 
+    <rect data-date="1947-04-01" data-gdp="246.3" class="bar"
+      x="2.909090909090909" y="394.5462697968967" width="2.909090909090909"
       height="5.453730203103289" transform="translate(60, 0)">
     </rect>
-    <rect data-date="1947-01-01" data-gdp="243.1" class="bar-misaligned" 
-      x="0" y="0" width="2.909090909090909" 
+    <rect data-date="1947-01-01" data-gdp="243.1" class="bar-misaligned"
+      x="0" y="0" width="2.909090909090909"
       height="5.382873781463295" transform="translate(60, 0)">
     </rect>
   `);
@@ -258,21 +259,24 @@ describe('D3 Alignment module tests', function() {
 
         it('should return before and after ticks for a given shape',
         function() {
-          const ticks = test.dom.window.document.querySelectorAll(
-            '#y-axis .tick'
+          let tickValues = [].map.call(
+            test.dom.window.document.querySelectorAll(
+              '#y-axis .tick'
+            ), tick => getTickValue(tick, test.dataType.y)
           );
+          const increment = tickValues[1] - tickValues[0];
+          tickValues = [
+            tickValues[0] - increment,
+            ...tickValues,
+            tickValues[tickValues.length - 1] + increment
+          ];
+
           const shapes =
             test.dom.window.document.querySelectorAll(test.shapeClassName);
 
-          const beginIndex = test.tickOrderNormalYAxis ? -1 : ticks.length;
-
           const alignedTicks = _getSurroundingTicks(
-            shapes[0],
             getShapeValue(shapes[0], test.attribute.y, test.dataType.y),
-            ticks,
-            beginIndex,
-            test.increment.y,
-            test.dataType.y,
+            tickValues,
             test.tickOrderNormalYAxis
           );
 


### PR DESCRIPTION
<!-- freeCodeCamp Testable Projects Pull Request Template -->

<!-- IMPORTANT: PRs against this repo should follow the general guidelines laid out for FCC's main repo as well as the guidlines specific to this repo -->
<!-- Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md && https://github.com/freeCodeCamp/testable-projects-fcc/blob/master/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] Your changes have been tested either locally or using a newly created CDN based on your fork's testable-projects-fcc/build/bundle.js file
- [ ] Working changes have been added to the build by running `npm run build`

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->

- [ ] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->

- [x] Tested changes locally.
<!-- replace XXX with an issue # -->
- [x] Closes currently open issue: Closes #493

#### Description
<!-- Describe your changes in detail -->
in https://codepen.io/freeCodeCamp/pen/GrZVaM, need to replace js code with that:
```javascript
const projectName = 'bar-chart';
localStorage.setItem('example_project', 'D3: Bar Chart');
// coded by @Christian-Paul

var yMargin = 40,
    width = 800,
    height = 400,
    barWidth = width/275;

var tooltip = d3.select(".visHolder").append("div")
  .attr("id", "tooltip")
  .style("opacity", 0);

var overlay = d3.select('.visHolder').append('div')
  .attr('class', 'overlay')
  .style('opacity', 0);

var svgContainer =  d3.select('.visHolder')
    .append('svg')
    .attr('width', width + 100)
    .attr('height', height + 60);

d3.json('https://raw.githubusercontent.com/FreeCodeCamp/ProjectReferenceData/master/GDP-data.json', function(err, data) {
  
  svgContainer.append('text')
    .attr('transform', 'rotate(-90)')
    .attr('x', -200)
    .attr('y', 80)
    .text('Gross Domestic Product');
  
  svgContainer.append('text')
    .attr('x', width/2 + 120)
    .attr('y', height + 50)
    .text('More Information: http://www.bea.gov/national/pdf/nipaguid.pdf')
    .attr('class', 'info');
  
  var years = data.data.map(function(item) {
    var quarter;
    var temp = item[0].substring(5, 7);
    
    if(temp === '01') {
      quarter = 'Q1';
    }
    else if (temp === '04'){
      quarter = 'Q2';
    }
    else if(temp === '07') {
      quarter = 'Q3';
    }
    else if(temp ==='10') {
      quarter = 'Q4';
    }

    return item[0].substring(0, 4) + ' ' + quarter
  });
  
  var yearsDate = data.data.map(function(item) {
    return new Date(item[0]);
  });

  var xMax = new Date(d3.max(yearsDate));
  xMax.setMonth(xMax.getMonth() + 3);
  var xScale = d3.scaleTime()
    .domain([d3.min(yearsDate), xMax])
    .range([0, width]);
  
  var xAxis = d3.axisBottom()
    .scale(xScale);
  
  var xAxisGroup = svgContainer.append('g')
    .call(xAxis)
    .attr('id', 'x-axis')
    .attr('transform', 'translate(60, 400)');
  
  var GDP = data.data.map(function(item) {
    return item[1]
  });
  
  var scaledGDP = [];
  
  var gdpMin = d3.min(GDP);
  var gdpMax = d3.max(GDP);
  
  var linearScale = d3.scaleLinear()
    .domain([0, gdpMax])
    .range([0, height]);
  
  scaledGDP = GDP.map(function(item) {
    return linearScale(item);
  });
  
  var yAxisScale = d3.scaleLinear()
    .domain([0, gdpMax])
    .range([height, 0]);
  
  var yAxis = d3.axisLeft(yAxisScale)
    
  var yAxisGroup = svgContainer.append('g')
    .call(yAxis)
    .attr('id', 'y-axis')
    .attr('transform', 'translate(60, 0)');
    
  d3.select('svg').selectAll('rect')
    .data(scaledGDP)
    .enter()
    .append('rect')
    .attr('data-date', function(d, i) {
      return data.data[i][0]
    })
    .attr('data-gdp', function(d, i) {
      return data.data[i][1]
    })
    .attr('class', 'bar')
    .attr('x', function(d, i) {
      return xScale(yearsDate[i]);
    })
    .attr('y', function(d, i) {
      return height - d;
    })
    .attr('width', barWidth)
    .attr('height', function(d) {
      return d;
    })
    .style('fill', '#33adff')
    .attr('transform', 'translate(60, 0)')
    .on('mouseover', function(d, i) {
      overlay.transition()
        .duration(0)
        .style('height', d + 'px')
        .style('width', barWidth + 'px')
        .style('opacity', .9)
        .style('left', (i * barWidth) + 0 + 'px')
        .style('top', height - d + 'px')
        .style('transform', 'translateX(60px)');
      tooltip.transition()
        .duration(200)
        .style('opacity', .9);
      tooltip.html(years[i] + '<br>' + '$' + GDP[i].toFixed(1).replace(/(\d)(?=(\d{3})+\.)/g, '$1,') + ' Billion')
        .attr('data-date', data.data[i][0])
        .style('left', (i * barWidth) + 30 + 'px')
        .style('top', height - 100 + 'px')
        .style('transform', 'translateX(60px)');
    })
    .on('mouseout', function(d) {
      tooltip.transition()
        .duration(200)
        .style('opacity', 0);
      overlay.transition()
        .duration(200)
        .style('opacity', 0);
    });

});
``` 