### PR TITLE
Revert "fix: typo"

### DIFF
--- a/src/project-tests/portfolio-tests.js
+++ b/src/project-tests/portfolio-tests.js
@@ -48,10 +48,10 @@ export default function createPortfolioTests() {
       });
 
       it(`The projects section should contain at least one element
-      with a class of "project-title" to hold a project.`,
+      with a class of "project-tile" to hold a project.`,
       function() {
         assert.isAbove(
-          document.querySelectorAll('#projects .project-title').length,
+          document.querySelectorAll('#projects .project-tile').length,
           0
         );
       });


### PR DESCRIPTION
Reverts freeCodeCamp/testable-projects-fcc#611

The user story says about a tile with information about a project.
> The projects section should contain at least one element with a class of `project-tile` to hold a project.

Closes #689