### PR TITLE
fix: assert time-left is formatted correctly

### DIFF
--- a/src/project-tests/pomodoro-clock-tests.js
+++ b/src/project-tests/pomodoro-clock-tests.js
@@ -218,7 +218,20 @@ export default function createPomodoroClockTests() {
       NOTE: Paused or running, the value in this field should always be
       displayed in mm:ss format (i.e. 25:00).`,
       function() {
-        assert.isNotNull(document.getElementById('time-left'));
+        const target = document.getElementById('time-left');
+        assert.isNotNull(target);
+        assert.strictEqual(
+          getMinutes(target.innerText),
+          '25',
+          'time-left is not formatted correctly'
+        );
+        // Set session length to 60
+        clickButtonsById(Array(35).fill(seshPlus));
+        assert.strictEqual(
+          getMinutes(target.innerText),
+          '60',
+          'time-left is not formatted correctly'
+        );
       });
 
       it(`I can see a clickable element with corresponding


### PR DESCRIPTION
<!-- freeCodeCamp Testable Projects Pull Request Template -->

<!-- IMPORTANT: PRs against this repo should follow the general guidelines laid out for FCC's main repo as well as the guidlines specific to this repo -->
<!-- Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/staging/CONTRIBUTING.md && https://github.com/freeCodeCamp/testable-projects-fcc/blob/master/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist
<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] Your changes have been tested either locally or using a newly created CDN based on your fork's testable-projects-fcc/build/bundle.js file
- [ ] Working changes have been added to the build by running `npm run build`

#### Type of Change
<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->

- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:
<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->

- [x] Tested changes locally.
<!-- replace XXX with an issue # -->
- [x] Closes currently open issue: Closes #755 

#### Description
<!-- Describe your changes in detail -->
This PR fixes an assertion issue for the pomodoro clock testing project. The issue was that all tests pass even if the `time-left` was incorrectly formatted as `00:00` instead of `60:00` when session length is set to `60`

The following screenshots demonstrate the fix

![image](https://user-images.githubusercontent.com/25670682/51281802-bcf5b280-19e3-11e9-94a7-3450961dfd9c.png)

![image](https://user-images.githubusercontent.com/25670682/51281821-ca12a180-19e3-11e9-9b78-53ac627b66ec.png)

An example project _before_ the fix can be found here: https://abdusabri.github.io/fcc-pomodoro-bug/
An example project _after_ the fix can be found here: https://abdusabri.github.io/fcc-pomodoro-fix/