### PR TITLE
feat: Add test to pomodoro-clock-tests

### DIFF
--- a/src/project-tests/pomodoro-clock-tests.js
+++ b/src/project-tests/pomodoro-clock-tests.js
@@ -291,9 +291,9 @@ export default function createPomodoroClockTests() {
         );
       });
 
-      it(`When I click the element with the id of "break-decrement" and then with the
-        id of "break-increment", both times element with the id "time-left" stays unchanged 
-        (time stays equal to the value of the element with the id "session-length")`, async function() {
+      it(`When I click the elements with the id of "break-decrement" and "break-increment" at 
+      the same time, the time indicated by the element with the id, "time-left", remains unchanged 
+      and equal to the value of the element with the id, "session-length".`, async function() {
         clickButtonsById([breakMin, breakPlus]);
 
         await timeout(1500);

--- a/src/project-tests/pomodoro-clock-tests.js
+++ b/src/project-tests/pomodoro-clock-tests.js
@@ -291,6 +291,29 @@ export default function createPomodoroClockTests() {
         );
       });
 
+      it(`When I click the element with the id of "break-decrement" and then with the
+        id of "break-increment", both times element with the id "time-left" stays unchanged 
+        (time stays equal to the value of the element with the id "session-length")`, async function() {
+        clickButtonsById([breakMin, breakPlus]);
+
+        await timeout(1500);
+
+        const timeLeftMins = getMinutes(
+          document.getElementById('time-left').innerText
+        );
+        const sessionLength = getInputValue(
+          document.getElementById('session-length')
+        );
+
+        assert.strictEqual(
+          timeLeftMins,
+          sessionLength,
+          'id="time-left" element has been changed'
+        );
+
+        resetTimer();
+      });
+
       it(`When I click the element with the id of "break-decrement",
       the value within id="break-length" decrements by a value of 1, and I can
       see the updated value.`, function() {


### PR DESCRIPTION
<!-- freeCodeCamp Testable Projects Pull Request Template -->

<!-- IMPORTANT: PRs against this repo should follow the general guidelines laid out for FCC's main repo as well as the guidlines specific to this repo -->
<!-- Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md && https://github.com/freeCodeCamp/testable-projects-fcc/blob/master/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist

<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] Your changes have been tested either locally or using a newly created CDN based on your fork's testable-projects-fcc/build/bundle.js file

#### Type of Change

<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->

- [ ] Small bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:

<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->

- [x] Tested changes locally.
  <!-- replace XXX with an issue # -->
- [ ] Closes currently open issue: Closes #XXX

#### Description

<!-- Describe your changes in detail -->

This PR adds new test to `pomodoro-clock-tests` that checks if `time-left` stays unchanged if breakMin or breakPlus are clicked. Because if that happen, and you press `start` - clock starts with break time instead of session time. That's the case when a developer doesn't check `timeType`. You can check how it works by changing `if (this.state.timerType === timerType)` in the example project to `if (this.state.timerType === !timerType)` (simply set ! before `timerType`) and then running tests.
