### PR TITLE
[Product Landing Page] Make tests pass when using non-hosted images (http src)

### DIFF
--- a/src/project-tests/product-landing-page-tests.js
+++ b/src/project-tests/product-landing-page-tests.js
@@ -43,11 +43,6 @@ export default function createProductLandingPageTests() {
           true,
           '#header-img must have a src attribute '
         );
-        assert.include(
-          img.src,
-          'http',
-          "The src attribute's value should be a url (http...) "
-        );
       });
 
       it(`Within the <header> element I can see a <nav> element with


### PR DESCRIPTION
#### Pre-Submission Checklist

- [x] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] Your changes have been tested either locally or using a newly created CDN based on your fork's testable-projects-fcc/build/bundle.js file

#### Type of Change

- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:

<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->

- [x] Tested changes locally.
  <!-- replace XXX with an issue # -->
- [ ] Closes currently open issue: Closes #XXX

#### Description

I was working on the Product Landing Page project when it occurred to me that the tests requires me to use an HTTP URL for my logo image source. This shouldn't be forced in my opinion. I store my images locally like most of us do. When I submit my projects to FCC using Codepen.io, I replace these URL's with the base code, so that all of my images are shown.

Let me know if removing the assert is fine. Another possibility would be to add an optional assert for a base code. 