### PR TITLE
fix(curriculum): Improve Bar Chart Project test #10

### DIFF
--- a/src/project-tests/bar-chart-tests.js
+++ b/src/project-tests/bar-chart-tests.js
@@ -181,7 +181,7 @@ export default function createBarChartTests() {
         const ticksCollection = axis.querySelectorAll('.tick');
         const shapeAttr = 'data-date';
         // options are 'minute', 'month', 'thousand', and 'year'
-        const dataType = 'year';
+        const dataType = 'year' || Date;
         // what vertex of shape to measure against the axis
         // options are 'topLeft' and 'center'
         const shapeAlign = 'topLeft';


### PR DESCRIPTION

- Addresses [#39299](https://github.com/freeCodeCamp/freeCodeCamp/issues/39299)
- Broadens acceptable values to `dataType` test parameters.
