### PR TITLE
fix(test): Update to support latest version of markedjs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -332,7 +332,7 @@ function loadMarked(callback) {
   if (typeof marked === 'undefined') {
     const markedCDN = document.createElement('script');
     markedCDN.src =
-      'https://cdnjs.cloudflare.com/ajax/libs/marked/0.5.0/marked.min.js';
+      'https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.2/marked.min.js';
     markedCDN.onload = callback;
     shadow.appendChild(markedCDN);
   } else {

--- a/src/project-tests/markdown-previewer-tests.js
+++ b/src/project-tests/markdown-previewer-tests.js
@@ -33,9 +33,14 @@ export default function createMarkdownPreviewerTests() {
       bold: false
     };
 
+    const libraryVersion = typeof marked;
+    if (libraryVersion !== 'undefined') {
+      findMarkdownMatches(markdownOnLoad || '', libraryVersion);
+    }
+
     // Parse the editor value using markedjs and override some of the renderers
     // so we can easily detect what markup was used.
-    function findMarkdownMatches(markdown) {
+    function findMarkdownMatches(markdown, libraryVersion) {
       const renderer = new marked.Renderer();
 
       renderer.heading = function (text, level) {
@@ -85,13 +90,11 @@ export default function createMarkdownPreviewerTests() {
         return '';
       };
 
-      marked(markdown, { renderer });
-    }
-
-    // At the beginning of the project, the Camper will might not have added
-    // the markedjs library yet.
-    if (typeof marked === 'function') {
-      findMarkdownMatches(markdownOnLoad || '');
+      if (libraryVersion === 'function') {
+        marked(markdown, { renderer });
+      } else if (libraryVersion === 'object') {
+        marked.parse(markdown, { renderer });
+      }
     }
 
     // As of React 15.6, we need a workaround that allows continued use of


### PR DESCRIPTION
<!-- freeCodeCamp Testable Projects Pull Request Template -->

<!-- IMPORTANT: PRs against this repo should follow the general guidelines laid out for FCC's main repo as well as the guidlines specific to this repo -->
<!-- Please review https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md && https://github.com/freeCodeCamp/testable-projects-fcc/blob/master/CONTRIBUTING.md for detailed contributing guidelines -->
<!-- Help with PRs can be found at https://gitter.im/FreeCodeCamp/Contributors -->
<!-- Make sure that your PR is not a duplicate -->

#### Pre-Submission Checklist

<!-- Go over all points below, and after creating the PR, tick all the checkboxes that apply. -->
<!-- All points should be verified, otherwise, read the CONTRIBUTING guidelines from above-->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Your pull request targets the `master` branch of freeCodeCamp/testable-projects-fcc
- [x] Branch starts with either `fix/`, `feature/`, or `translate/` (e.g. `fix/signin-issue`)
- [x] You have only one commit (if not, [squash](http://forum.freecodecamp.com/t/how-to-squash-multiple-commits-into-one-with-git/13231) them into one commit).
- [x] Your changes have been tested either locally or using a newly created CDN based on your fork's testable-projects-fcc/build/bundle.js file

#### Type of Change

<!-- What type of change does your code introduce? After creating the PR, tick the checkboxes that apply. -->

- [x] Small bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Add new translation (feature adding new translations)

#### Checklist:

<!-- Go over all points below, and after creating the PR, tick the checkboxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask in the Help Contributors room linked above. We're here to help! -->

- [x] Tested changes locally.
<!-- replace XXX with an issue # -->
- [ ] Closes currently open issue: Closes #XXX

#### Description

Markdown projects are failing tests they shouldn't with the latest version 4 of markedjs when loaded using Codepen settings or a script element.

TL;DR explanation. We had a `typeof` check that was failing. `typeof marked` can return 'function' or 'object' depending on the version of the library and how it is loaded.

---

Forum: https://forum.freecodecamp.org/t/markdown-previewer-solution-fails-tests-5-and-6-despite-functioning-as-intended/484737

Example Codepen with the old and new versions of tests and library.
https://codepen.io/lasjorg/pen/jOGEqbL?editors=1010

Note that `marked.parse(props.markdown, { renderer: renderer })` (Line: 108) is used in this example.

---

Very much not TL;DR explanation: I apologize in advance for the long and somewhat confusing explanation. Frankly, at this point, I'm a little confused myself.

When version 4 of markedjs is loaded using the JS section in the Codepen settings or as a script element `typeof marked` returns `'object'`. Version 3 and below of markedjs returns `'function'`.

When using the import syntax on Codepen.

```
// is logged out as an object when logged in the JS code box
`import * as marked from "https://cdn.skypack.dev/marked@4.0.5";`

// is logged out as a function when logged in the JS code box
`import { marked } from "https://cdn.skypack.dev/marked@4.0.5";`
```

However, if you do the same console.log in the browser console _manually before_ running the tests it will return `undefined`. It being `undefined` will (afaict) cause us to load our version of the library found in `src\index.js` when you run the test. Which is (or was) an old version that would also report typeof 'function'. As far as I can tell, it looks like when the camper uses the Codepen import syntax we will always load the script found in `src\index.js`.

The test internally uses the markedjs library. As long as `typeof marked` doesn't return `undefined` we (afaict) use the version that is loaded by the project being tested. If the project does not load the library, i.e. `typeof marked` does return `undefined` we use our own version. That code is in `src\index.js` inside the function `loadMarked`.

This is why currently when using import on Codepen it will make projects that are using version 4 of markedjs pass the tests again as it causes the old version of the library to be loaded which will not fail the `typeof marked === 'function'` check.

If I'm right about this then another option instead of this PR would be to never use the version loaded by the project and always use our own version for the tests. This approach is likely more future-proof. It would also be preferable to use an npm package for maintainability instead of a CDN link. The only downside I can see is it would increase the bundle size.


---

Side note: We should probably update the example project to use the latest version of the library as well. It would be a small PR. I might do it later at some point.