### PR TITLE
chore: do not downgrade firefox

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,15 +39,6 @@ jobs:
         run: |
           yarn install
 
-      - name: Downgrade Firefox
-        if: matrix.browser == 'firefox'
-        run: |
-          curl https://ftp.mozilla.org/pub/firefox/releases/101.0/linux-x86_64/en-US/firefox-101.0.tar.bz2 --output firefox-101.0.tar.bz2
-          tar -xjf firefox-101.0.tar.bz2
-          sudo mv firefox /opt/
-          sudo mv /usr/bin/firefox /usr/bin/firefox_old
-          sudo ln -s /opt/firefox/firefox /usr/bin/firefox
-
       - name: update test fixture
         run: yarn cy:gen:fix
 


### PR DESCRIPTION
Removes the step to downgrade Firefox because the underlying issue has been resolved